### PR TITLE
cmake: remove unnecessary FILE field

### DIFF
--- a/src/samconf/CMakeLists.txt
+++ b/src/samconf/CMakeLists.txt
@@ -53,7 +53,6 @@ install(
   EXPORT samconfTargets
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/samconf
   NAMESPACE samconf::
-  FILE samconfTargets.cmake # Not sure if this is still needed
 )
 
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
The FILE option may be used to specify a different name than `<export-name>`. Since, we already use `samconfTargets` as `<export-name>`, `samconfTargets.cmake` is already the default value.

Documentation source: https://cmake.org/cmake/help/latest/command/install.html#export